### PR TITLE
Firing onChange event when cmEditor is changed

### DIFF
--- a/src/js/module/Codeview.js
+++ b/src/js/module/Codeview.js
@@ -59,7 +59,8 @@ define([
           $editable = layoutInfo.editable(),
           $codable = layoutInfo.codable(),
           $popover = layoutInfo.popover(),
-          $handle = layoutInfo.handle();
+          $handle = layoutInfo.handle(),
+          $holder = layoutInfo.holder();
 
       var options = $editor.data('options');
 
@@ -86,6 +87,18 @@ define([
             server.updateArgHints(cm);
           });
         }
+        
+        // fire onChange event for cmEditor's onkeyup
+        cmEditor.on('keyup', function (e) {
+          var value = cmEditor.getValue();
+          var isChange = $editable.html() !== value;
+
+          if (isChange) {
+            handler.bindCustomEvent(
+                $holder, $editable.data('callbacks'), 'change'
+            )(value, $editable);
+          }
+        });
 
         // CodeMirror hasn't Padding.
         cmEditor.setSize(null, $editable.outerHeight());

--- a/src/js/module/Codeview.js
+++ b/src/js/module/Codeview.js
@@ -89,7 +89,7 @@ define([
         }
         
         // fire onChange event for cmEditor's onkeyup
-        cmEditor.on('keyup', function (e) {
+        cmEditor.on('keyup', function () {
           var value = cmEditor.getValue();
           var isChange = $editable.html() !== value;
 


### PR DESCRIPTION
Changing the CodeView's cmEditor does not fire an onChange event, so if you have external JavaScript listening to the onChange event, it is not fired when the user edits the content in the code view.

fixes #977
